### PR TITLE
meta 데이터 ETL 구현

### DIFF
--- a/dags/meta.py
+++ b/dags/meta.py
@@ -15,7 +15,7 @@ with DAG(
     description="Processing weather data",
     schedule="@daily",
     start_date=datetime(2023, 1, 1),
-    end_date=datetime(2025, 4, 2),
+    end_date=datetime(2024, 6, 1),
     catchup=True,
     max_active_runs=1,
     tags=["spark", "submit", "meta"],
@@ -26,12 +26,9 @@ with DAG(
 
     create_meta = BashOperator(
         task_id="create_meta",
-        # bash_command=""" # -> 인스턴스용
-        #     ssh -i ~/.ssh/gcp-joon-key joon@34.47.101.222 \
-        #     "/home/joon/code/WeatherTunes/features/meta/run.sh {{ ds_nodash }} /home/joon/code/WeatherTunes/features/meta/a.py"
-        # """
-        bash_command="""
-            "/Users/joon/swcamp4/code/WeatherTunes/features/meta/run.sh {{ ds_nodash }} /Users/joon/swcamp4/code/WeatherTunes/features/meta/a.py"
+        bash_command=""" # -> 인스턴스용
+            ssh -i ~/.ssh/gcp-joon-key joon@34.47.101.222 \
+            "/home/joon/code/WeatherTunes/features/meta/run.sh {{ ds_nodash }} /home/joon/code/WeatherTunes/features/meta/a.py"
         """
     )
 

--- a/dags/meta.py
+++ b/dags/meta.py
@@ -1,0 +1,55 @@
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.bash import BashOperator
+from datetime import datetime, timedelta
+import sys
+import os
+
+# 💡 scripts 디렉토리 경로 추가
+sys.path.append(os.path.join(os.path.dirname(__file__), "../script"))
+from app import generate_meta_profile
+
+default_args = {
+    "owner": "airflow",
+    "start_date": datetime(2025, 4, 13),
+    "end_date": datetime(2025, 4, 16),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=2),
+}
+
+with DAG(
+    dag_id="dag_generate_meta_profile",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    catchup=True,
+    tags=["meta", "profile"]
+) as dag:
+
+    start = EmptyOperator(task_id="start")
+
+    # 🧪 Spark 함수로 meta profile 생성 후 GCS 저장
+
+    generate = BashOperator(
+        task_id="generate_meta_profile",
+        bash_command="""
+        spark-submit \
+        /home/gmlwls5168/airflow/script/app.py {{ ds_nodash }}
+        """
+    )
+
+    # 📦 BigQuery로 parquet 파일 업로드
+    copy_to_bigquery = BashOperator(
+        task_id="copy_to_bigquery",
+        bash_command="""
+        bq load \
+        --source_format=PARQUET \
+        --autodetect \
+        --replace \
+        praxis-zoo-455400-d2:meta_dataset.meta_profile \
+        gs://nijin-bucket/meta/meta_profile/{{ ds_nodash }}/weather_main=0/temp_band=1/*.parquet
+        """
+    )
+
+    end = EmptyOperator(task_id="end")
+
+    start >> generate >> copy_to_bigquery >> end

--- a/dags/meta.py
+++ b/dags/meta.py
@@ -39,7 +39,6 @@ with DAG(
         bq load \
         --source_format=PARQUET \
         --autodetect \
-        --append \
         weathertunes:meta.meta \
         gs://jacob_weathertunes/meta/dt={{ ds_nodash }}/*.parquet
         """

--- a/features/meta/a.py
+++ b/features/meta/a.py
@@ -1,51 +1,33 @@
-import os
+import sys
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import lit
+from pyspark.sql.functions import lit, broadcast
 
-def generate_meta_profile(date: str):
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "/home/gmlwls5168/keys/praxis-zoo-455400-d2-e1891bf1943d.json"
-
-    spark = SparkSession.builder \
-        .appName("MetaProfileGenerator") \
-        .getOrCreate()
-
-    # GCS 경로 설정
-    base = "gs://nijin-bucket/dummy"
-    weather_path = f"{base}/weather_daily/partition={date}/"
-    songs_path = f"{base}/songs_top200/partition={date}/"
-    audio_path = f"{base}/audio_features/partition={date}/"
-
-    # 데이터 로드 (parquet 파일이 한 개만 존재한다고 가정)
+def merge_data(weather_path: str, songs_path: str, audio_features_path: str, save_path: str, dt: str):
+    spark = SparkSession.builder.appName(f"merge_meta_{dt}") \
+            .config("spark.sql.sources.partitionOverwriteMode", "dynamic") \
+            .getOrCreate()
+    
     weather_df = spark.read.parquet(weather_path)
-    songs_df = spark.read.parquet(songs_path)
-    audio_df = spark.read.parquet(audio_path)
-
-    # 병합
-    merged = songs_df.join(audio_df, on="track_id", how="inner")
-
-    # 날씨 값 추출 및 컬럼 추가
-    weather_row = weather_df.limit(1).collect()[0]
-
-    merged = merged.withColumn("weather_main", lit(weather_main))
-    merged = merged.withColumn("temp_band", lit(temp_band))
-    merged = merged.withColumn("date", lit(date))
-    # ✅ GCS에 저장할 경로
-    output_path = f"gs://nijin-bucket/meta/meta_profile/{date}/weather_main={weather_main}/temp_band={temp_band}/"
-
-    # 저장
-    merged.write.mode("overwrite").partitionBy("date").parquet(output_path)
-
-    print(f"✅ 저장 완료: {output_path}")
+    songs_df = spark.read.parquet(songs_path) \
+        .filter("days_on_chart < 30") \
+        .select("track_id", "artist_names", "track_name", "streams")
+    audio_features_df = spark.read.parquet(audio_features_path)
+    
+    merged_song_df = songs_df.join(broadcast(audio_features_df), on="track_id", how="left")
+    result_df = merged_song_df.join(weather_df, on="dt", how="left")
+    result_df = result_df.withColumn("dt", lit(dt))
+    
+    result_df.write.mode("overwrite") \
+        .partitionBy("dt", "weather_code", "temp_code") \
+        .parquet(save_path)
+        
+    print(f"✅ 저장 완료: {save_path} (dt={dt})")
 
 if __name__ == "__main__":
-    import sys
-    main(sys.argv[1])
-
-    # BigQuery 업로드
-    # client = bigquery.Client()
-    # table_id = "praxis-zoo-455400-d2.meta_dataset.meta_profile"
-    # job_config = bigquery.LoadJobConfig(write_disposition="WRITE_APPEND")
-    # job = client.load_table_from_dataframe(merged, table_id, job_config=job_config)
-    # job.result()
-
-    # print(f"✅ 업로드 완료: {date}")
+    ds_nodash = sys.argv[1]
+    weather_path = f"gs://jacob_weathertunes/data/weather_data/dt={ds_nodash}/"
+    songs_path = f"gs://jacob_weathertunes/data/songs_top200/dt={ds_nodash}/"
+    audio_features_path = f"gs://jacob_weathertunes/data/audio_features/"
+    save_path = f"gs://jacob_weathertunes/meta/"
+    
+    merge_data(weather_path, songs_path, audio_features_path, save_path, ds_nodash)

--- a/features/meta/a.py
+++ b/features/meta/a.py
@@ -1,0 +1,51 @@
+import os
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import lit
+
+def generate_meta_profile(date: str):
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "/home/gmlwls5168/keys/praxis-zoo-455400-d2-e1891bf1943d.json"
+
+    spark = SparkSession.builder \
+        .appName("MetaProfileGenerator") \
+        .getOrCreate()
+
+    # GCS 경로 설정
+    base = "gs://nijin-bucket/dummy"
+    weather_path = f"{base}/weather_daily/partition={date}/"
+    songs_path = f"{base}/songs_top200/partition={date}/"
+    audio_path = f"{base}/audio_features/partition={date}/"
+
+    # 데이터 로드 (parquet 파일이 한 개만 존재한다고 가정)
+    weather_df = spark.read.parquet(weather_path)
+    songs_df = spark.read.parquet(songs_path)
+    audio_df = spark.read.parquet(audio_path)
+
+    # 병합
+    merged = songs_df.join(audio_df, on="track_id", how="inner")
+
+    # 날씨 값 추출 및 컬럼 추가
+    weather_row = weather_df.limit(1).collect()[0]
+
+    merged = merged.withColumn("weather_main", lit(weather_main))
+    merged = merged.withColumn("temp_band", lit(temp_band))
+    merged = merged.withColumn("date", lit(date))
+    # ✅ GCS에 저장할 경로
+    output_path = f"gs://nijin-bucket/meta/meta_profile/{date}/weather_main={weather_main}/temp_band={temp_band}/"
+
+    # 저장
+    merged.write.mode("overwrite").partitionBy("date").parquet(output_path)
+
+    print(f"✅ 저장 완료: {output_path}")
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv[1])
+
+    # BigQuery 업로드
+    # client = bigquery.Client()
+    # table_id = "praxis-zoo-455400-d2.meta_dataset.meta_profile"
+    # job_config = bigquery.LoadJobConfig(write_disposition="WRITE_APPEND")
+    # job = client.load_table_from_dataframe(merged, table_id, job_config=job_config)
+    # job.result()
+
+    # print(f"✅ 업로드 완료: {date}")

--- a/features/meta/a.py
+++ b/features/meta/a.py
@@ -8,9 +8,12 @@ def merge_data(weather_path: str, songs_path: str, audio_features_path: str, sav
             .getOrCreate()
     
     weather_df = spark.read.parquet(weather_path)
+    weather_df = weahter_df.withColumn("dt", lit(dt))
+
     songs_df = spark.read.parquet(songs_path) \
         .filter("days_on_chart < 30") \
         .select("track_id", "artist_names", "track_name", "streams")
+
     audio_features_df = spark.read.parquet(audio_features_path)
     
     merged_song_df = songs_df.join(broadcast(audio_features_df), on="track_id", how="left")

--- a/features/meta/a.py
+++ b/features/meta/a.py
@@ -8,7 +8,7 @@ def merge_data(weather_path: str, songs_path: str, audio_features_path: str, sav
             .getOrCreate()
     
     weather_df = spark.read.parquet(weather_path)
-    weather_df = weahter_df.withColumn("dt", lit(dt))
+    weather_df = weather_df.withColumn("dt", lit(dt))
 
     songs_df = spark.read.parquet(songs_path) \
         .filter("days_on_chart < 30") \

--- a/features/meta/a.py
+++ b/features/meta/a.py
@@ -17,6 +17,8 @@ def merge_data(weather_path: str, songs_path: str, audio_features_path: str, sav
     audio_features_df = spark.read.parquet(audio_features_path)
     
     merged_song_df = songs_df.join(broadcast(audio_features_df), on="track_id", how="left")
+    merged_song_df = merged_song_df.withColumn("dt", lit(dt))
+
     result_df = merged_song_df.join(weather_df, on="dt", how="left")
     result_df = result_df.withColumn("dt", lit(dt))
     

--- a/features/meta/run.sh
+++ b/features/meta/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SPARK_HOME=/home/joon/app/spark-3.5.1-bin-hadoop3
+DS_NODASH=$1
+PY_PATH=$2
+
+$SPARK_HOME/bin/spark-submit \
+--master spark://spark-jerry-1.asia-northeast3-c.c.wiki-455500.internal:7077 \
+--executor-memory 2G \
+--executor-cores 2 \
+$PY_PATH $DS_NODASH

--- a/features/meta/run.sh
+++ b/features/meta/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPARK_HOME=/home/joon/app/spark-3.5.1-bin-hadoop3
+SPARK_HOME=/home/joon/app/spark-3.5.1-bin-hadoop3
 DS_NODASH=$1
 PY_PATH=$2
 

--- a/features/meta/run.sh
+++ b/features/meta/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SPARK_HOME=/home/joon/app/spark-3.5.1-bin-hadoop3
+# SPARK_HOME=/home/joon/app/spark-3.5.1-bin-hadoop3
 DS_NODASH=$1
 PY_PATH=$2
 
@@ -8,4 +8,4 @@ $SPARK_HOME/bin/spark-submit \
 --master spark://spark-jerry-1.asia-northeast3-c.c.wiki-455500.internal:7077 \
 --executor-memory 2G \
 --executor-cores 2 \
-$PY_PATH $DS_NODASH
+$PY_PATH $DS_NODASH 


### PR DESCRIPTION
1. 날짜 별로 날씨 데이터와 Top200 곡을 dt로 join하여 저장
2. Top 200 곡은 각 곡의 audio_features와 track_id로 join하여 저장
3. meta에는 날짜, 날씨 코드, 기온 코드에 맞는 곡들이 들어가있다.
4. 저장되는 곡들은 노이즈(차트에 연속으로 30일 이상 있는 곡)가 제거된 곡들이 저장되어있다.